### PR TITLE
Fix#2

### DIFF
--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -653,9 +653,17 @@ pub fn parse_path(buffer: &[u8], mut i: usize) -> Result<usize, Error> {
 	loop {
 		match get_char(buffer, i)? {
 			None | Some(('?', _)) | Some(('#', _)) => break,
-			Some((_, len)) => {
+			Some(('%', 1)) => {
+				if let Some(len) = parse_pct_encoded(buffer, i)? {
+					i += len
+				} else {
+					break
+				}
+			},
+			Some((c, len)) if is_subdelim(c) || is_unreserved(c) || c == '@' || c == ':' || c == '/' => {
 				i += len
-			}
+			},
+			_ => break
 		}
 	}
 
@@ -669,9 +677,17 @@ pub fn parse_path_segment(buffer: &[u8], mut i: usize) -> Result<usize, Error> {
 	loop {
 		match get_char(buffer, i)? {
 			None | Some(('?', _)) | Some(('#', _)) | Some(('/', _)) => break,
-			Some((_, len)) => {
+			Some(('%', 1)) => {
+				if let Some(len) = parse_pct_encoded(buffer, i)? {
+					i += len
+				} else {
+					break
+				}
+			},
+			Some((c, len)) if is_subdelim(c) || is_unreserved(c) || c == '@' || c == ':' => {
 				i += len
-			}
+			},
+			_ => break
 		}
 	}
 

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -68,3 +68,12 @@ fn test7() {
 	assert!(iri.authority().is_none());
 	assert_eq!(iri.path(), "foo/bar");
 }
+
+#[test]
+#[should_panic]
+fn test8() {
+	let buffer = "https:foo/bar space";
+	let iri = Iri::new(buffer).unwrap();
+
+	println!("{}", iri.path());
+}

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -77,3 +77,11 @@ fn test8() {
 
 	println!("{}", iri.path());
 }
+
+#[test]
+fn test9() {
+	let iri1 = Iri::new("https:foo/bar").unwrap();
+	let iri2 = Iri::new("https:foo/%62%61%72").unwrap();
+
+	assert_eq!(iri1, iri2)
+}


### PR DESCRIPTION
This fixes #2 and add new tests.

The parser was accepting too much characters for path and segments. More importantly, percent encoded character were ignored.