### PR TITLE
Add from_str and to_owned methods

### DIFF
--- a/src/iri/buffer.rs
+++ b/src/iri/buffer.rs
@@ -1,13 +1,16 @@
-use super::{
-	AsIri, AsIriRef, Authority, AuthorityMut, Error, Fragment, Iri, IriRef, Path, PathMut, Query,
-	Scheme,
+use std::{
+	cmp::{Ord, Ordering, PartialOrd},
+	convert::TryFrom,
+	fmt,
+	hash::{Hash, Hasher},
+	ops::Deref,
+	str::FromStr,
 };
-use crate::IriRefBuf;
-use std::cmp::{Ord, Ordering, PartialOrd};
-use std::convert::TryFrom;
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
+
+use crate::{
+	iri::Iri, AsIri, AsIriRef, Authority, AuthorityMut, Error, Fragment, IriRef, IriRefBuf, Path,
+	PathMut, Query, Scheme,
+};
 
 /// Owned IRI.
 #[derive(Clone)]
@@ -85,6 +88,14 @@ impl IriBuf {
 	#[inline]
 	pub fn set_fragment(&mut self, fragment: Option<Fragment>) {
 		self.0.set_fragment(fragment)
+	}
+}
+
+impl FromStr for IriBuf {
+	type Err = Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Self::new(s)
 	}
 }
 

--- a/src/iri/mod.rs
+++ b/src/iri/mod.rs
@@ -154,7 +154,7 @@ impl<'a> Iri<'a> {
 		Self::new(s)
 	}
 
-	/// Convert the slice-like [`Iri`] into the owned version [`IriRef`].
+	/// Convert the slice-like [`Iri`] into the owned version [`IriBuf`].
 	pub fn to_owned(self) -> IriBuf {
 		IriBuf(self.0.to_owned())
 	}

--- a/src/iri/mod.rs
+++ b/src/iri/mod.rs
@@ -146,6 +146,19 @@ impl<'a> Iri<'a> {
 		}
 	}
 
+	/// Create a new IRI from a string.
+	///
+	/// This replaces a [`std::str::FromStr`] implementation as the trait is
+	/// incompatiple with the result storing the input which [`Iri`] does.
+	pub fn from_str(s: &'a str) -> Result<Self, Error> {
+		Self::new(s)
+	}
+
+	/// Convert the slice-like [`Iri`] into the owned version [`IriRef`].
+	pub fn to_owned(self) -> IriBuf {
+		IriBuf(self.0.to_owned())
+	}
+
 	/// Build an IRI from an IRI reference.
 	#[inline]
 	pub const fn from_iri_ref(iri_ref: IriRef<'a>) -> Iri<'a> {

--- a/src/reference/buffer.rs
+++ b/src/reference/buffer.rs
@@ -1,15 +1,18 @@
-use super::IriRef;
-use crate::parsing::ParsedIriRef;
-use crate::{
-	AsIriRef, Authority, AuthorityMut, Error, Fragment, Iri, IriBuf, Path, PathBuf, PathMut, Query,
-	Scheme,
+use std::{
+	cmp::{Ord, Ordering, PartialOrd},
+	convert::TryInto,
+	fmt,
+	hash::{Hash, Hasher},
+	ops::Range,
+	str::FromStr,
 };
+
 use pct_str::PctStr;
-use std::cmp::{Ord, Ordering, PartialOrd};
-use std::convert::TryInto;
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::ops::Range;
+
+use crate::{
+	parsing::ParsedIriRef, AsIriRef, Authority, AuthorityMut, Error, Fragment, Iri, IriBuf, IriRef,
+	Path, PathBuf, PathMut, Query, Scheme,
+};
 
 /// Owned IRI-reference.
 ///
@@ -324,6 +327,14 @@ impl IriRefBuf {
 	#[inline]
 	pub fn resolved<'b, Base: Into<Iri<'b>>>(&self, base_iri: Base) -> IriBuf {
 		self.as_iri_ref().resolved(base_iri)
+	}
+}
+
+impl FromStr for IriRefBuf {
+	type Err = Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Self::new(s)
 	}
 }
 

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -53,6 +53,22 @@ impl<'a> IriRef<'a> {
 		})
 	}
 
+	/// Create a new IRI-reference from a string.
+	///
+	/// This replaces a [`std::str::FromStr`] implementation as the trait is
+	/// incompatiple with the result storing the input which [`IriRef`] does.
+	pub fn from_str(s: &'a str) -> Result<Self, Error> {
+		Self::new(s)
+	}
+
+	/// Convert the slice-like [`IriRef`] into the owned version [`IriRefBuf`].
+	pub fn to_owned(self) -> IriRefBuf {
+		IriRefBuf {
+			p: self.p,
+			data: self.data.to_vec(),
+		}
+	}
+
 	/// Get the underlying parsing data.
 	#[inline]
 	pub fn parsing_data(&self) -> ParsedIriRef {


### PR DESCRIPTION
As requested in #6 this PR adds `from_str` and `to_owned()` methods.

Actually, I could only implement `FromStr` for `IriBuf` and `IriRefBuf` as `FromStr` assumes that the result does not store the input. The same for `ToOwned` and `Borrow` traits. `ToOwned` required a reciprocal `Borrow` implementation. Probably, I could implement `impl Borrow<Iri<'a>> for IriBuf` with some unsafe pointer vodoo but actually that's a problem of missing DSTs... so I didn't wanted to go to far.