### PR TITLE
Replace magic numbers with byte literals

### DIFF
--- a/src/iri/authority.rs
+++ b/src/iri/authority.rs
@@ -208,7 +208,7 @@ impl<'a> AuthorityMut<'a> {
 			if let Some(userinfo_len) = self.p.userinfo_len {
 				self.replace(offset..(offset + userinfo_len), new_userinfo.as_ref());
 			} else {
-				self.replace(offset..offset, &[0x40]);
+				self.replace(offset..offset, b"@");
 				self.replace(offset..offset, new_userinfo.as_ref());
 			}
 
@@ -258,7 +258,7 @@ impl<'a> AuthorityMut<'a> {
 			if let Some(port_len) = self.p.port_len {
 				self.replace(offset..(offset + port_len), new_port.as_ref());
 			} else {
-				self.replace(offset..offset, &[0x3a]);
+				self.replace(offset..offset, b":");
 				self.replace((offset + 1)..(offset + 1), new_port.as_ref());
 			}
 

--- a/src/iri/segment.rs
+++ b/src/iri/segment.rs
@@ -19,7 +19,7 @@ impl<'a> Segment<'a> {
 	#[inline]
 	pub fn current() -> Segment<'static> {
 		Segment {
-			data: &[0x2e],
+			data: b".",
 			open: false,
 		}
 	}
@@ -28,7 +28,7 @@ impl<'a> Segment<'a> {
 	#[inline]
 	pub fn parent() -> Segment<'static> {
 		Segment {
-			data: &[0x2e, 0x2e],
+			data: b"..",
 			open: false,
 		}
 	}
@@ -96,7 +96,7 @@ impl<'a> TryFrom<&'a str> for Segment<'a> {
 		let segment_len = parsing::parse_path_segment(str.as_ref(), 0)?;
 		let data: &[u8] = str.as_ref();
 		if segment_len < data.len() {
-			if segment_len == data.len() - 1 && data[segment_len] == 0x2f {
+			if segment_len == data.len() - 1 && data[segment_len] == b'/' {
 				Ok(Segment {
 					data: &data[0..segment_len],
 					open: true,

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -247,20 +247,17 @@ pub fn get_char(buffer: &[u8], i: usize) -> Result<Option<(char, usize)>, Error>
 
 #[inline]
 pub fn is_alpha(c: char) -> bool {
-	let c = c as u32;
-	(0x41..=0x5a).contains(&c) || (0x61..=0x7a).contains(&c)
+	c.is_ascii_alphabetic()
 }
 
 #[inline]
 pub fn is_digit(c: char) -> bool {
-	let c = c as u32;
-	(0x30..=0x39).contains(&c)
+	c.is_ascii_digit()
 }
 
 #[inline]
 pub fn is_alphanumeric(c: char) -> bool {
-	let c = c as u32;
-	(0x30..=0x39).contains(&c) || (0x41..=0x5a).contains(&c) || (0x61..=0x7a).contains(&c)
+	c.is_ascii_alphanumeric()
 }
 
 /// Parse the IRI scheme.

--- a/src/reference/buffer.rs
+++ b/src/reference/buffer.rs
@@ -126,7 +126,7 @@ impl IriRefBuf {
 			if let Some(scheme_len) = self.p.scheme_len {
 				self.replace(0..scheme_len, new_scheme.as_ref());
 			} else {
-				self.replace(0..0, &[0x3a]);
+				self.replace(0..0, b":");
 				self.replace(0..0, new_scheme.as_ref());
 			}
 
@@ -181,7 +181,7 @@ impl IriRefBuf {
 				self.replace(offset..(offset + authority.len()), new_authority.as_ref());
 			} else {
 				self.replace(offset..offset, new_authority.as_ref());
-				self.replace(offset..offset, &[0x2f, 0x2f]);
+				self.replace(offset..offset, b"//");
 			}
 
 			self.p.authority = Some(new_authority.p);
@@ -235,7 +235,7 @@ impl IriRefBuf {
 			if let Some(query_len) = self.p.query_len {
 				self.replace(offset..(offset + query_len), new_query.as_ref());
 			} else {
-				self.replace(offset..offset, &[0x3f]);
+				self.replace(offset..offset, b":");
 				self.replace((offset + 1)..(offset + 1), new_query.as_ref());
 			}
 
@@ -268,7 +268,7 @@ impl IriRefBuf {
 			if let Some(fragment_len) = self.p.fragment_len {
 				self.replace(offset..(offset + fragment_len), new_fragment.as_ref());
 			} else {
-				self.replace(offset..offset, &[0x23]);
+				self.replace(offset..offset, b"#");
 				self.replace((offset + 1)..(offset + 1), new_fragment.as_ref());
 			}
 


### PR DESCRIPTION
While scanning the code for #10 I noticed that constants like a forward slash were represented by hex-codes. While understandable I took the opportunity to replace those _magic numbers_ with byte literals (`b""` for arrays and `b''` for single characters). This doesn't alter the code but improves readability.