### PR TITLE
feat(std): add std feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ keywords.workspace = true
 license.workspace = true
 
 [features]
+std = ["iref-core/std"]
 default = []
 macros = ["dep:iref-macros"]
 serde = ["iref-core/serde"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,7 +12,9 @@ keywords.workspace = true
 license.workspace = true
 
 [features]
-default = []
+default = ["std"]
+std = []
+ignore-grammars = []
 serde = ["dep:serde"]
 data = ["dep:base64"]
 hashbrown = ["dep:hashbrown"]

--- a/crates/core/src/common/authority.rs
+++ b/crates/core/src/common/authority.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 use crate::uri::Port;
 

--- a/crates/core/src/common/authority_mut.rs
+++ b/crates/core/src/common/authority_mut.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, ops::Range};
+use core::{marker::PhantomData, ops::Range};
 
 use super::{
 	authority::{AuthorityImpl, HostImpl, UserInofImpl},

--- a/crates/core/src/common/parse.rs
+++ b/crates/core/src/common/parse.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 fn is_scheme_char(b: u8) -> bool {
 	// ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )

--- a/crates/core/src/common/path.rs
+++ b/crates/core/src/common/path.rs
@@ -445,7 +445,7 @@ pub struct NormalizedSegmentsImpl<'a, P: ?Sized + PathImpl>(
 );
 
 impl<'a, P: ?Sized + PathImpl> NormalizedSegmentsImpl<'a, P> {
-	fn new(path: &'a P) -> NormalizedSegmentsImpl<P> {
+	fn new(path: &'a P) -> Self {
 		let relative = path.is_relative();
 		let mut stack = SmallVec::<[&'a P::Segment; NORMALIZE_STACK_SIZE]>::new();
 

--- a/crates/core/src/common/path.rs
+++ b/crates/core/src/common/path.rs
@@ -332,7 +332,7 @@ pub trait PathImpl: 'static {
 	///
 	/// # Example
 	/// ```
-	/// # use std::convert::TryFrom;
+	/// # use core::convert::TryFrom;
 	/// # use iref_core as iref;
 	/// use iref::iri::{Path, PathBuf};
 	///

--- a/crates/core/src/common/path_mut.rs
+++ b/crates/core/src/common/path_mut.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, ops::Deref};
+use core::{marker::PhantomData, ops::Deref};
 
 use smallvec::SmallVec;
 

--- a/crates/core/src/common/reference.rs
+++ b/crates/core/src/common/reference.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 use super::{
 	parse, AuthorityImpl, AuthorityMutImpl, FragmentImpl, PathImpl, PathMutImpl, QueryImpl,

--- a/crates/core/src/iri/authority.rs
+++ b/crates/core/src/iri/authority.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 };
@@ -34,7 +34,7 @@ impl AuthorityImpl for Authority {
 	type Host = Host;
 
 	unsafe fn new_unchecked(bytes: &[u8]) -> &Self {
-		Self::new_unchecked(std::str::from_utf8_unchecked(bytes))
+		Self::new_unchecked(core::str::from_utf8_unchecked(bytes))
 	}
 
 	fn as_bytes(&self) -> &[u8] {

--- a/crates/core/src/iri/authority/host.rs
+++ b/crates/core/src/iri/authority/host.rs
@@ -1,5 +1,5 @@
 use pct_str::{PctStr, PctString};
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 	ops,
@@ -25,7 +25,7 @@ pub struct Host(str);
 
 impl HostImpl for Host {
 	unsafe fn new_unchecked(bytes: &[u8]) -> &Self {
-		Self::new_unchecked(std::str::from_utf8_unchecked(bytes))
+		Self::new_unchecked(core::str::from_utf8_unchecked(bytes))
 	}
 
 	fn as_bytes(&self) -> &[u8] {

--- a/crates/core/src/iri/authority/userinfo.rs
+++ b/crates/core/src/iri/authority/userinfo.rs
@@ -1,5 +1,5 @@
 use pct_str::{PctStr, PctString};
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 	ops,
@@ -27,7 +27,7 @@ pub struct UserInfo(str);
 
 impl UserInofImpl for UserInfo {
 	unsafe fn new_unchecked(bytes: &[u8]) -> &Self {
-		Self::new_unchecked(std::str::from_utf8_unchecked(bytes))
+		Self::new_unchecked(core::str::from_utf8_unchecked(bytes))
 	}
 
 	fn as_bytes(&self) -> &[u8] {

--- a/crates/core/src/iri/authority_mut.rs
+++ b/crates/core/src/iri/authority_mut.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use core::ops::Deref;
 
 use crate::common::authority_mut::AuthorityMutImpl;
 

--- a/crates/core/src/iri/fragment.rs
+++ b/crates/core/src/iri/fragment.rs
@@ -1,5 +1,5 @@
 use pct_str::{PctStr, PctString};
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 	ops,
@@ -28,7 +28,7 @@ pub struct Fragment(str);
 
 impl FragmentImpl for Fragment {
 	unsafe fn new_unchecked(bytes: &[u8]) -> &Self {
-		Self::new_unchecked(std::str::from_utf8_unchecked(bytes))
+		Self::new_unchecked(core::str::from_utf8_unchecked(bytes))
 	}
 
 	fn as_bytes(&self) -> &[u8] {

--- a/crates/core/src/iri/mod.rs
+++ b/crates/core/src/iri/mod.rs
@@ -3,10 +3,7 @@ use core::{
 	hash::{self, Hash},
 };
 
-#[cfg(not(feature = "std"))]
-use alloc::borrow::Cow;
-#[cfg(feature = "std")]
-use std::borrow::Cow;
+use crate::Cow;
 
 use static_regular_grammar::RegularGrammar;
 

--- a/crates/core/src/iri/mod.rs
+++ b/crates/core/src/iri/mod.rs
@@ -1,7 +1,12 @@
-use std::{
-	borrow::{Borrow, Cow},
+use core::{
+	borrow::Borrow,
 	hash::{self, Hash},
 };
+
+#[cfg(not(feature = "std"))]
+use alloc::borrow::Cow;
+#[cfg(feature = "std")]
+use std::borrow::Cow;
 
 use static_regular_grammar::RegularGrammar;
 
@@ -260,7 +265,7 @@ impl Iri {
 	/// ```
 	#[inline]
 	pub fn base(&self) -> &Self {
-		unsafe { Self::new_unchecked(std::str::from_utf8_unchecked(RiRefImpl::base(self))) }
+		unsafe { Self::new_unchecked(core::str::from_utf8_unchecked(RiRefImpl::base(self))) }
 	}
 }
 
@@ -339,43 +344,43 @@ impl PartialEq<IriRefBuf> for Iri {
 impl Eq for Iri {}
 
 impl PartialOrd for Iri {
-	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
 		Some(self.cmp(other))
 	}
 }
 
 impl<'a> PartialOrd<&'a Iri> for Iri {
-	fn partial_cmp(&self, other: &&'a Self) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a Self) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(*other)
 	}
 }
 
 impl PartialOrd<IriBuf> for Iri {
-	fn partial_cmp(&self, other: &IriBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &IriBuf) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_iri())
 	}
 }
 
 impl PartialOrd<IriRef> for Iri {
-	fn partial_cmp(&self, other: &IriRef) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &IriRef) -> Option<core::cmp::Ordering> {
 		self.as_iri_ref().partial_cmp(other)
 	}
 }
 
 impl<'a> PartialOrd<&'a IriRef> for Iri {
-	fn partial_cmp(&self, other: &&'a IriRef) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a IriRef) -> Option<core::cmp::Ordering> {
 		self.as_iri_ref().partial_cmp(*other)
 	}
 }
 
 impl PartialOrd<IriRefBuf> for Iri {
-	fn partial_cmp(&self, other: &IriRefBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &IriRefBuf) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_iri_ref())
 	}
 }
 
 impl Ord for Iri {
-	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+	fn cmp(&self, other: &Self) -> core::cmp::Ordering {
 		self.parts().cmp(&other.parts())
 	}
 }
@@ -628,19 +633,19 @@ impl PartialEq<IriRefBuf> for IriBuf {
 }
 
 impl PartialOrd<IriRef> for IriBuf {
-	fn partial_cmp(&self, other: &IriRef) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &IriRef) -> Option<core::cmp::Ordering> {
 		self.as_iri_ref().partial_cmp(other)
 	}
 }
 
 impl<'a> PartialOrd<&'a IriRef> for IriBuf {
-	fn partial_cmp(&self, other: &&'a IriRef) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a IriRef) -> Option<core::cmp::Ordering> {
 		self.as_iri_ref().partial_cmp(*other)
 	}
 }
 
 impl PartialOrd<IriRefBuf> for IriBuf {
-	fn partial_cmp(&self, other: &IriRefBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &IriRefBuf) -> Option<core::cmp::Ordering> {
 		self.as_iri_ref().partial_cmp(other.as_iri_ref())
 	}
 }

--- a/crates/core/src/iri/path.rs
+++ b/crates/core/src/iri/path.rs
@@ -31,7 +31,7 @@ impl PathImpl for Path {
 	type Owned = PathBuf;
 
 	unsafe fn new_unchecked(bytes: &[u8]) -> &Self {
-		Self::new_unchecked(std::str::from_utf8_unchecked(bytes))
+		Self::new_unchecked(core::str::from_utf8_unchecked(bytes))
 	}
 
 	#[inline(always)]
@@ -195,7 +195,7 @@ impl Path {
 	///
 	/// # Example
 	/// ```
-	/// # use std::convert::TryFrom;
+	/// # use core::convert::TryFrom;
 	/// # use iref_core as iref;
 	/// use iref::iri::{Path, PathBuf};
 	///
@@ -257,15 +257,15 @@ impl Eq for Path {}
 
 impl PartialOrd for Path {
 	#[inline]
-	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
 		Some(self.cmp(other))
 	}
 }
 
 impl Ord for Path {
 	#[inline]
-	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-		use std::cmp::Ordering;
+	fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+		use core::cmp::Ordering;
 		if self.is_absolute() == other.is_absolute() {
 			let mut self_segments = self.normalized_segments();
 			let mut other_segments = other.normalized_segments();
@@ -290,9 +290,9 @@ impl Ord for Path {
 	}
 }
 
-impl std::hash::Hash for Path {
+impl core::hash::Hash for Path {
 	#[inline]
-	fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
+	fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) {
 		self.is_absolute().hash(hasher);
 		self.normalized_segments().for_each(move |s| s.hash(hasher))
 	}

--- a/crates/core/src/iri/path/segment.rs
+++ b/crates/core/src/iri/path/segment.rs
@@ -1,5 +1,5 @@
 use pct_str::PctStr;
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 	ops,
@@ -32,7 +32,7 @@ impl SegmentImpl for Segment {
 	const EMPTY: &'static Self = Self::EMPTY;
 
 	unsafe fn new_unchecked(bytes: &[u8]) -> &Self {
-		Self::new_unchecked(std::str::from_utf8_unchecked(bytes))
+		Self::new_unchecked(core::str::from_utf8_unchecked(bytes))
 	}
 
 	fn as_bytes(&self) -> &[u8] {

--- a/crates/core/src/iri/path_mut.rs
+++ b/crates/core/src/iri/path_mut.rs
@@ -1,5 +1,5 @@
 use crate::common::path_mut::PathMutImpl;
-use std::ops::Deref;
+use core::ops::Deref;
 
 use super::{path::Segment, Path, PathBuf};
 

--- a/crates/core/src/iri/query.rs
+++ b/crates/core/src/iri/query.rs
@@ -1,5 +1,5 @@
 use pct_str::{PctStr, PctString};
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 	ops,
@@ -25,7 +25,7 @@ pub struct Query(str);
 
 impl QueryImpl for Query {
 	unsafe fn new_unchecked(bytes: &[u8]) -> &Self {
-		Self::new_unchecked(std::str::from_utf8_unchecked(bytes))
+		Self::new_unchecked(core::str::from_utf8_unchecked(bytes))
 	}
 
 	fn as_bytes(&self) -> &[u8] {

--- a/crates/core/src/iri/reference.rs
+++ b/crates/core/src/iri/reference.rs
@@ -1,4 +1,4 @@
-use std::hash::{self, Hash};
+use core::hash::{self, Hash};
 
 use static_regular_grammar::RegularGrammar;
 
@@ -169,7 +169,7 @@ impl IriRef {
 	/// ```
 	#[inline]
 	pub fn base(&self) -> &Self {
-		unsafe { Self::new_unchecked(std::str::from_utf8_unchecked(RiRefImpl::base(self))) }
+		unsafe { Self::new_unchecked(core::str::from_utf8_unchecked(RiRefImpl::base(self))) }
 	}
 }
 
@@ -238,43 +238,43 @@ impl PartialEq<IriBuf> for IriRef {
 impl Eq for IriRef {}
 
 impl PartialOrd for IriRef {
-	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
 		Some(self.cmp(other))
 	}
 }
 
 impl<'a> PartialOrd<&'a IriRef> for IriRef {
-	fn partial_cmp(&self, other: &&'a Self) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a Self) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(*other)
 	}
 }
 
 impl PartialOrd<IriRefBuf> for IriRef {
-	fn partial_cmp(&self, other: &IriRefBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &IriRefBuf) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_iri_ref())
 	}
 }
 
 impl PartialOrd<Iri> for IriRef {
-	fn partial_cmp(&self, other: &Iri) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Iri) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_iri_ref())
 	}
 }
 
 impl<'a> PartialOrd<&'a Iri> for IriRef {
-	fn partial_cmp(&self, other: &&'a Iri) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a Iri) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_iri_ref())
 	}
 }
 
 impl PartialOrd<IriBuf> for IriRef {
-	fn partial_cmp(&self, other: &IriBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &IriBuf) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_iri_ref())
 	}
 }
 
 impl Ord for IriRef {
-	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+	fn cmp(&self, other: &Self) -> core::cmp::Ordering {
 		self.parts().cmp(&other.parts())
 	}
 }
@@ -556,19 +556,19 @@ impl PartialEq<IriBuf> for IriRefBuf {
 }
 
 impl PartialOrd<Iri> for IriRefBuf {
-	fn partial_cmp(&self, other: &Iri) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Iri) -> Option<core::cmp::Ordering> {
 		self.as_iri_ref().partial_cmp(other.as_iri_ref())
 	}
 }
 
 impl<'a> PartialOrd<&'a Iri> for IriRefBuf {
-	fn partial_cmp(&self, other: &&'a Iri) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a Iri) -> Option<core::cmp::Ordering> {
 		self.as_iri_ref().partial_cmp(other.as_iri_ref())
 	}
 }
 
 impl PartialOrd<IriBuf> for IriRefBuf {
-	fn partial_cmp(&self, other: &IriBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &IriBuf) -> Option<core::cmp::Ordering> {
 		self.as_iri_ref().partial_cmp(other.as_iri_ref())
 	}
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub(crate) mod common;
 pub mod iri;
 pub mod uri;
@@ -5,3 +7,8 @@ pub(crate) mod utils;
 
 pub use iri::{InvalidIri, Iri, IriBuf, IriError, IriRef, IriRefBuf};
 pub use uri::{InvalidUri, Uri, UriBuf, UriError, UriRef, UriRefBuf};
+
+#[cfg(not(feature = "std"))]
+pub(crate) use alloc::borrow::Cow;
+#[cfg(feature = "std")]
+pub(crate) use std::borrow::Cow;

--- a/crates/core/src/uri/authority.rs
+++ b/crates/core/src/uri/authority.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 };

--- a/crates/core/src/uri/authority/host.rs
+++ b/crates/core/src/uri/authority/host.rs
@@ -1,5 +1,5 @@
 use pct_str::{PctStr, PctString};
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 	ops,

--- a/crates/core/src/uri/authority/userinfo.rs
+++ b/crates/core/src/uri/authority/userinfo.rs
@@ -1,5 +1,5 @@
 use pct_str::{PctStr, PctString};
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 	ops,

--- a/crates/core/src/uri/authority_mut.rs
+++ b/crates/core/src/uri/authority_mut.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use core::ops::Deref;
 
 use crate::common::authority_mut::AuthorityMutImpl;
 

--- a/crates/core/src/uri/fragment.rs
+++ b/crates/core/src/uri/fragment.rs
@@ -1,5 +1,5 @@
 use pct_str::{PctStr, PctString};
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 	ops,

--- a/crates/core/src/uri/mod.rs
+++ b/crates/core/src/uri/mod.rs
@@ -1,5 +1,5 @@
 use static_regular_grammar::RegularGrammar;
-use std::{
+use core::{
 	borrow::{Borrow, Cow},
 	hash::{self, Hash},
 };
@@ -165,11 +165,11 @@ impl Uri {
 	}
 
 	pub fn as_iri(&self) -> &Iri {
-		unsafe { Iri::new_unchecked(std::str::from_utf8_unchecked(&self.0)) }
+		unsafe { Iri::new_unchecked(core::str::from_utf8_unchecked(&self.0)) }
 	}
 
 	pub fn as_iri_ref(&self) -> &IriRef {
-		unsafe { IriRef::new_unchecked(std::str::from_utf8_unchecked(&self.0)) }
+		unsafe { IriRef::new_unchecked(core::str::from_utf8_unchecked(&self.0)) }
 	}
 
 	/// Returns the scheme of the URI.
@@ -322,43 +322,43 @@ impl PartialEq<UriRefBuf> for Uri {
 impl Eq for Uri {}
 
 impl PartialOrd for Uri {
-	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
 		Some(self.cmp(other))
 	}
 }
 
 impl<'a> PartialOrd<&'a Uri> for Uri {
-	fn partial_cmp(&self, other: &&'a Self) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a Self) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(*other)
 	}
 }
 
 impl PartialOrd<UriBuf> for Uri {
-	fn partial_cmp(&self, other: &UriBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &UriBuf) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_uri())
 	}
 }
 
 impl PartialOrd<UriRef> for Uri {
-	fn partial_cmp(&self, other: &UriRef) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &UriRef) -> Option<core::cmp::Ordering> {
 		self.as_uri_ref().partial_cmp(other)
 	}
 }
 
 impl<'a> PartialOrd<&'a UriRef> for Uri {
-	fn partial_cmp(&self, other: &&'a UriRef) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a UriRef) -> Option<core::cmp::Ordering> {
 		self.as_uri_ref().partial_cmp(*other)
 	}
 }
 
 impl PartialOrd<UriRefBuf> for Uri {
-	fn partial_cmp(&self, other: &UriRefBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &UriRefBuf) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_uri_ref())
 	}
 }
 
 impl Ord for Uri {
-	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+	fn cmp(&self, other: &Self) -> core::cmp::Ordering {
 		self.parts().cmp(&other.parts())
 	}
 }
@@ -602,19 +602,19 @@ impl PartialEq<UriRefBuf> for UriBuf {
 }
 
 impl PartialOrd<UriRef> for UriBuf {
-	fn partial_cmp(&self, other: &UriRef) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &UriRef) -> Option<core::cmp::Ordering> {
 		self.as_uri_ref().partial_cmp(other)
 	}
 }
 
 impl<'a> PartialOrd<&'a UriRef> for UriBuf {
-	fn partial_cmp(&self, other: &&'a UriRef) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a UriRef) -> Option<core::cmp::Ordering> {
 		self.as_uri_ref().partial_cmp(*other)
 	}
 }
 
 impl PartialOrd<UriRefBuf> for UriBuf {
-	fn partial_cmp(&self, other: &UriRefBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &UriRefBuf) -> Option<core::cmp::Ordering> {
 		self.as_uri_ref().partial_cmp(other.as_uri_ref())
 	}
 }

--- a/crates/core/src/uri/mod.rs
+++ b/crates/core/src/uri/mod.rs
@@ -1,8 +1,13 @@
-use static_regular_grammar::RegularGrammar;
 use core::{
-	borrow::{Borrow, Cow},
+	borrow::Borrow,
 	hash::{self, Hash},
 };
+use static_regular_grammar::RegularGrammar;
+
+#[cfg(not(feature = "std"))]
+use alloc::borrow::Cow;
+#[cfg(feature = "std")]
+use std::borrow::Cow;
 
 mod authority;
 mod authority_mut;

--- a/crates/core/src/uri/path.rs
+++ b/crates/core/src/uri/path.rs
@@ -196,7 +196,7 @@ impl Path {
 	///
 	/// # Example
 	/// ```
-	/// # use std::convert::TryFrom;
+	/// # use core::convert::TryFrom;
 	/// # use iref_core as iref;
 	/// use iref::iri::{Path, PathBuf};
 	///
@@ -282,15 +282,15 @@ impl Eq for Path {}
 
 impl PartialOrd for Path {
 	#[inline]
-	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
 		Some(self.cmp(other))
 	}
 }
 
 impl Ord for Path {
 	#[inline]
-	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-		use std::cmp::Ordering;
+	fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+		use core::cmp::Ordering;
 		if self.is_absolute() == other.is_absolute() {
 			let mut self_segments = self.normalized_segments();
 			let mut other_segments = other.normalized_segments();
@@ -315,9 +315,9 @@ impl Ord for Path {
 	}
 }
 
-impl std::hash::Hash for Path {
+impl core::hash::Hash for Path {
 	#[inline]
-	fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
+	fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) {
 		self.is_absolute().hash(hasher);
 		self.normalized_segments().for_each(move |s| s.hash(hasher))
 	}

--- a/crates/core/src/uri/path/segment.rs
+++ b/crates/core/src/uri/path/segment.rs
@@ -1,5 +1,5 @@
 use pct_str::PctStr;
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 	ops,

--- a/crates/core/src/uri/path_mut.rs
+++ b/crates/core/src/uri/path_mut.rs
@@ -1,5 +1,5 @@
 use crate::common::path_mut::PathMutImpl;
-use std::ops::Deref;
+use core::ops::Deref;
 
 use super::{path::Segment, Path, PathBuf};
 

--- a/crates/core/src/uri/query.rs
+++ b/crates/core/src/uri/query.rs
@@ -1,5 +1,5 @@
 use pct_str::{PctStr, PctString};
-use std::{
+use core::{
 	cmp,
 	hash::{self, Hash},
 	ops,

--- a/crates/core/src/uri/reference.rs
+++ b/crates/core/src/uri/reference.rs
@@ -1,4 +1,4 @@
-use std::hash::{self, Hash};
+use core::hash::{self, Hash};
 
 use static_regular_grammar::RegularGrammar;
 
@@ -82,7 +82,7 @@ impl UriRef {
 	#[inline]
 	pub fn as_iri(&self) -> Option<&Iri> {
 		if self.scheme().is_some() {
-			Some(unsafe { Iri::new_unchecked(std::str::from_utf8_unchecked(&self.0)) })
+			Some(unsafe { Iri::new_unchecked(core::str::from_utf8_unchecked(&self.0)) })
 		} else {
 			None
 		}
@@ -90,7 +90,7 @@ impl UriRef {
 
 	#[inline]
 	pub fn as_iri_ref(&self) -> &IriRef {
-		unsafe { IriRef::new_unchecked(std::str::from_utf8_unchecked(&self.0)) }
+		unsafe { IriRef::new_unchecked(core::str::from_utf8_unchecked(&self.0)) }
 	}
 
 	/// Returns the scheme of the URI reference, if any.
@@ -245,43 +245,43 @@ impl PartialEq<UriBuf> for UriRef {
 impl Eq for UriRef {}
 
 impl PartialOrd for UriRef {
-	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
 		Some(self.cmp(other))
 	}
 }
 
 impl<'a> PartialOrd<&'a UriRef> for UriRef {
-	fn partial_cmp(&self, other: &&'a Self) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a Self) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(*other)
 	}
 }
 
 impl PartialOrd<UriRefBuf> for UriRef {
-	fn partial_cmp(&self, other: &UriRefBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &UriRefBuf) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_uri_ref())
 	}
 }
 
 impl PartialOrd<Uri> for UriRef {
-	fn partial_cmp(&self, other: &Uri) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Uri) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_uri_ref())
 	}
 }
 
 impl<'a> PartialOrd<&'a Uri> for UriRef {
-	fn partial_cmp(&self, other: &&'a Uri) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a Uri) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_uri_ref())
 	}
 }
 
 impl PartialOrd<UriBuf> for UriRef {
-	fn partial_cmp(&self, other: &UriBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &UriBuf) -> Option<core::cmp::Ordering> {
 		self.partial_cmp(other.as_uri_ref())
 	}
 }
 
 impl Ord for UriRef {
-	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+	fn cmp(&self, other: &Self) -> core::cmp::Ordering {
 		self.parts().cmp(&other.parts())
 	}
 }
@@ -543,19 +543,19 @@ impl PartialEq<UriBuf> for UriRefBuf {
 }
 
 impl PartialOrd<Uri> for UriRefBuf {
-	fn partial_cmp(&self, other: &Uri) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &Uri) -> Option<core::cmp::Ordering> {
 		self.as_uri_ref().partial_cmp(other.as_uri_ref())
 	}
 }
 
 impl<'a> PartialOrd<&'a Uri> for UriRefBuf {
-	fn partial_cmp(&self, other: &&'a Uri) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &&'a Uri) -> Option<core::cmp::Ordering> {
 		self.as_uri_ref().partial_cmp(other.as_uri_ref())
 	}
 }
 
 impl PartialOrd<UriBuf> for UriRefBuf {
-	fn partial_cmp(&self, other: &UriBuf) -> Option<std::cmp::Ordering> {
+	fn partial_cmp(&self, other: &UriBuf) -> Option<core::cmp::Ordering> {
 		self.as_uri_ref().partial_cmp(other.as_uri_ref())
 	}
 }

--- a/crates/core/src/uri/scheme/data.rs
+++ b/crates/core/src/uri/scheme/data.rs
@@ -1,8 +1,5 @@
-use core::{
-	borrow::{Borrow, Cow},
-	ops::Deref,
-	str::FromStr,
-};
+use crate::Cow;
+use core::{borrow::Borrow, ops::Deref, str::FromStr};
 
 use base64::Engine;
 

--- a/crates/core/src/uri/scheme/data.rs
+++ b/crates/core/src/uri/scheme/data.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
 	borrow::{Borrow, Cow},
 	ops::Deref,
 	str::FromStr,
@@ -49,7 +49,7 @@ impl DataUrl {
 	///
 	/// The input value must be a data URL.
 	pub unsafe fn new_unchecked(url: &(impl ?Sized + AsRef<[u8]>)) -> &Self {
-		std::mem::transmute(url.as_ref())
+		core::mem::transmute(url.as_ref())
 	}
 
 	pub fn parts(&self) -> DataUrlPartsRef {

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 pub fn allocate_range(buffer: &mut Vec<u8>, range: Range<usize>, len: usize) {
 	let range_len = range.end - range.start;

--- a/examples/buffer.rs
+++ b/examples/buffer.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use core::borrow::Cow;
 
 use iref::{IriBuf, IriError};
 

--- a/examples/resolution.rs
+++ b/examples/resolution.rs
@@ -1,4 +1,4 @@
-use core::borrow::Cow;
+use std::borrow::Cow;
 
 use iref::{Iri, IriError, IriRefBuf};
 

--- a/examples/resolution.rs
+++ b/examples/resolution.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use core::borrow::Cow;
 
 use iref::{Iri, IriError, IriRefBuf};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@
 //! Thanks to the [`pct-str` crate](https://crates.io/crates/pct-str),
 //! percent encoded characters are correctly handled.
 //! The two IRIs `http://example.org` and `http://exa%6dple.org` **are** equivalent.
-#![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub use iref_core::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,12 @@
 //! Thanks to the [`pct-str` crate](https://crates.io/crates/pct-str),
 //! percent encoded characters are correctly handled.
 //! The two IRIs `http://example.org` and `http://exa%6dple.org` **are** equivalent.
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
+
 pub use iref_core::*;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 #[cfg(feature = "macros")]
 pub use iref_macros::*;


### PR DESCRIPTION
This PR should allow the crate to run in `no_std` contexts when the standard library is not available.