### PR TITLE
Fix PctStr/PctString len bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+    branches: ["**"]
 
 env:
   CARGO_TERM_COLORS: always

--- a/src/uri/authority/mut.rs
+++ b/src/uri/authority/mut.rs
@@ -130,10 +130,11 @@ impl<'a> AuthorityMut<'a> {
 						self.replace_bytes(userinfo_range, new_userinfo.as_bytes())
 					}
 					None => {
+						let new_userinfo = new_userinfo.as_bytes();
 						let added_len = new_userinfo.len() + 1;
 						self.allocate_bytes(self.range.start..self.range.start, added_len);
 						self.data[self.range.start..(self.range.start + new_userinfo.len())]
-							.copy_from_slice(new_userinfo.as_bytes());
+							.copy_from_slice(new_userinfo);
 						self.data[self.range.start + new_userinfo.len()] = b'@';
 						self.range.end += added_len
 					}
@@ -192,6 +193,7 @@ impl<'a> AuthorityMut<'a> {
 		let bytes = &self.data[..self.range.end];
 		let range = crate::common::parse::find_host(bytes, self.range.start);
 		let host_len = range.end - range.start;
+		let host = host.as_bytes();
 
 		if host_len > host.len() {
 			self.range.end -= host_len - host.len()
@@ -199,7 +201,7 @@ impl<'a> AuthorityMut<'a> {
 			self.range.end -= host.len() - host_len
 		}
 
-		self.replace_bytes(range, host.as_bytes());
+		self.replace_bytes(range, host);
 		self
 	}
 
@@ -331,34 +333,74 @@ mod tests {
 
 	#[test]
 	fn set_user_info() {
-		let mut data = b"http://user:pass@example.com:8080/path".to_vec();
-		let mut authority_mut = AuthorityMut::new(&mut data, 7..33).unwrap();
+		let vectors: &[(&[u8], Range<usize>, Option<&str>, &[u8])] = &[
+			(
+				b"http://user:pass@example.com:8080/path",
+				7..33,
+				Some("user"),
+				b"http://user@example.com:8080/path",
+			),
+			(
+				b"http://user:pass@example.com:8080/path",
+				7..33,
+				Some("user:pass"),
+				b"http://user:pass@example.com:8080/path",
+			),
+			(
+				b"http://user:pass@example.com:8080/path",
+				7..33,
+				None,
+				b"http://example.com:8080/path",
+			),
+			(
+				b"http://user:pass@example.com:8080/path",
+				7..33,
+				Some("%75ser:pass"),
+				b"http://%75ser:pass@example.com:8080/path",
+			),
+		];
 
-		let new_user_info = UserInfo::new("new_user:new_pass").unwrap();
-		authority_mut.set_user_info(Some(&new_user_info));
-		assert_eq!(
-			authority_mut.as_authority().user_info().unwrap(),
-			"new_user:new_pass"
-		);
-
-		authority_mut.set_user_info(None);
-		assert!(authority_mut.as_authority().user_info().is_none());
-
-		authority_mut.set_user_info(Some(&new_user_info));
-		assert_eq!(
-			authority_mut.as_authority().user_info().unwrap(),
-			"new_user:new_pass"
-		);
+		for (input_data, range, user_info, expected) in vectors {
+			let mut data = input_data.to_vec();
+			let mut authority_mut = AuthorityMut::new(&mut data, range.clone()).unwrap();
+			let new_user_info = user_info.map(|i| UserInfo::new(i).unwrap());
+			authority_mut.set_user_info(new_user_info);
+			assert_eq!(authority_mut.as_authority().user_info(), new_user_info);
+			assert_eq!(data, expected.to_vec());
+		}
 	}
 
 	#[test]
 	fn set_host() {
-		let mut data = b"http://user:pass@example.com:8080/path".to_vec();
-		let mut authority_mut = AuthorityMut::new(&mut data, 7..33).unwrap();
+		let vectors: &[(&[u8], Range<usize>, &str, &[u8])] = &[
+			(
+				b"http://user:pass@example.com:8080/path",
+				7..33,
+				"new_host.org",
+				b"http://user:pass@new_host.org:8080/path",
+			),
+			(
+				b"http://user:pass@example.com:8080/path",
+				7..33,
+				"%6Eew.org",
+				b"http://user:pass@%6Eew.org:8080/path",
+			),
+			(
+				b"http://user:pass@%65xample.com:8080/path",
+				7..35,
+				"example.com",
+				b"http://user:pass@example.com:8080/path",
+			),
+		];
 
-		let new_host = Host::new("new_host.org").unwrap();
-		authority_mut.set_host(&new_host);
-		assert_eq!(authority_mut.as_authority().host(), "new_host.org");
+		for (input_data, range, host, expected) in vectors {
+			let mut data = input_data.to_vec();
+			let mut authority_mut = AuthorityMut::new(&mut data, range.clone()).unwrap();
+			let new_host = Host::new(host).unwrap();
+			authority_mut.set_host(&new_host);
+			assert_eq!(authority_mut.as_authority().host(), new_host);
+			assert_eq!(data, expected.to_vec());
+		}
 	}
 
 	#[test]

--- a/src/uri/authority/mut.rs
+++ b/src/uri/authority/mut.rs
@@ -198,7 +198,7 @@ impl<'a> AuthorityMut<'a> {
 		if host_len > host.len() {
 			self.range.end -= host_len - host.len()
 		} else {
-			self.range.end -= host.len() - host_len
+			self.range.end += host.len() - host_len
 		}
 
 		self.replace_bytes(range, host);
@@ -384,6 +384,18 @@ mod tests {
 				7..33,
 				"%6Eew.org",
 				b"http://user:pass@%6Eew.org:8080/path",
+			),
+			(
+				b"http://user:pass@example.com:8080/path",
+				7..33,
+				"new_long_host.org",
+				b"http://user:pass@new_long_host.org:8080/path",
+			),
+			(
+				b"http://user:pass@example.com:8080/path",
+				7..33,
+				"%6Eew_long_host.org",
+				b"http://user:pass@%6Eew_long_host.org:8080/path",
 			),
 			(
 				b"http://user:pass@%65xample.com:8080/path",

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -617,8 +617,7 @@ impl UriBuf {
 					let bytes = self.as_mut_vec();
 					let delim_end = start + 1;
 					bytes[start] = b'?';
-					bytes[delim_end..(delim_end + new_query.len())]
-						.copy_from_slice(new_query)
+					bytes[delim_end..(delim_end + new_query.len())].copy_from_slice(new_query)
 				},
 			},
 			None => {
@@ -672,8 +671,7 @@ impl UriBuf {
 					let bytes = self.as_mut_vec();
 					let delim_end = start + 1;
 					bytes[start] = b'#';
-					bytes[delim_end..(delim_end + new_fragment.len())]
-						.copy_from_slice(new_fragment)
+					bytes[delim_end..(delim_end + new_fragment.len())].copy_from_slice(new_fragment)
 				},
 			},
 			None => {
@@ -1071,18 +1069,18 @@ mod tests {
 				Some("bar"),
 				"scheme://bar/path?query#frag",
 			),
-			(
-				"scheme:",
-				Some("%61uthority"),
-				"scheme://%61uthority/",
-			),
+			("scheme:", Some("%61uthority"), "scheme://%61uthority/"),
 		];
 
 		for (input_uri, input_authority, expected) in vectors {
 			let mut uri = UriBuf::new(input_uri.to_string()).unwrap();
 			let authority = input_authority.map(|a| Authority::new(a).unwrap());
 			uri.set_authority(authority);
-			assert_eq!(uri.as_str(), *expected, "input uri: {input_uri}, authority: {input_authority:?}");
+			assert_eq!(
+				uri.as_str(),
+				*expected,
+				"input uri: {input_uri}, authority: {input_authority:?}"
+			);
 		}
 	}
 
@@ -1184,7 +1182,11 @@ mod tests {
 			let mut uri = UriBuf::new(input_uri.to_string()).unwrap();
 			let query = input_query.map(|q| Query::new(q).unwrap());
 			uri.set_query(query);
-			assert_eq!(uri.as_str(), *expected, "input uri: {input_uri}, query: {input_query:?}");
+			assert_eq!(
+				uri.as_str(),
+				*expected,
+				"input uri: {input_uri}, query: {input_query:?}"
+			);
 		}
 	}
 
@@ -1264,7 +1266,11 @@ mod tests {
 			let mut uri = UriBuf::new(input_uri.to_string()).unwrap();
 			let fragment = input_fragment.map(|f| Fragment::new(f).unwrap());
 			uri.set_fragment(fragment);
-			assert_eq!(uri.as_str(), *expected, "input uri: {input_uri}, fragment: {input_fragment:?}");
+			assert_eq!(
+				uri.as_str(),
+				*expected,
+				"input uri: {input_uri}, fragment: {input_fragment:?}"
+			);
 		}
 	}
 

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -1166,16 +1166,6 @@ mod tests {
 				None,
 				"scheme://authority/path#frag",
 			),
-			(
-				"scheme://authority/path?%71uery#frag",
-				Some("%71uery"),
-				"scheme://authority/path?%71uery#frag",
-			),
-			(
-				"scheme://authority/path?%71uery#frag",
-				None,
-				"scheme://authority/path#frag",
-			),
 		];
 
 		for (input_uri, input_query, expected) in vectors {
@@ -1239,11 +1229,6 @@ mod tests {
 				"scheme://authority/path#%66rag",
 				Some("frag"),
 				"scheme://authority/path#frag",
-			),
-			(
-				"scheme://authority/path#%66rag",
-				Some("%66rag"),
-				"scheme://authority/path#%66rag",
 			),
 			(
 				"scheme://authority/path#%66rag",

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -612,12 +612,13 @@ impl UriBuf {
 			Some(new_query) => match crate::common::parse::find_query(self.as_bytes(), 0) {
 				Ok(range) => unsafe { self.replace(range, new_query.as_bytes()) },
 				Err(start) => unsafe {
+					let new_query = new_query.as_bytes();
 					self.allocate(start..start, new_query.len() + 1);
 					let bytes = self.as_mut_vec();
 					let delim_end = start + 1;
 					bytes[start] = b'?';
 					bytes[delim_end..(delim_end + new_query.len())]
-						.copy_from_slice(new_query.as_bytes())
+						.copy_from_slice(new_query)
 				},
 			},
 			None => {
@@ -666,12 +667,13 @@ impl UriBuf {
 			Some(new_fragment) => match crate::common::parse::find_fragment(self.as_bytes(), 0) {
 				Ok(range) => unsafe { self.replace(range, new_fragment.as_bytes()) },
 				Err(start) => unsafe {
+					let new_fragment = new_fragment.as_bytes();
 					self.allocate(start..start, new_fragment.len() + 1);
 					let bytes = self.as_mut_vec();
 					let delim_end = start + 1;
 					bytes[start] = b'#';
 					bytes[delim_end..(delim_end + new_fragment.len())]
-						.copy_from_slice(new_fragment.as_bytes())
+						.copy_from_slice(new_fragment)
 				},
 			},
 			None => {
@@ -1042,6 +1044,49 @@ mod tests {
 	}
 
 	#[test]
+	fn set_authority() {
+		let vectors: &[(&str, Option<&str>, &str)] = &[
+			(
+				"scheme://authority/path?query#frag",
+				Some("authority"),
+				"scheme://authority/path?query#frag",
+			),
+			(
+				"scheme://authority/path?query#frag",
+				None,
+				"scheme:/path?query#frag",
+			),
+			(
+				"scheme://authority/path?query#frag",
+				Some("bar"),
+				"scheme://bar/path?query#frag",
+			),
+			(
+				"scheme://authority/path?query#frag",
+				Some("%61uthority"),
+				"scheme://%61uthority/path?query#frag",
+			),
+			(
+				"scheme://%61uthority/path?query#frag",
+				Some("bar"),
+				"scheme://bar/path?query#frag",
+			),
+			(
+				"scheme:",
+				Some("%61uthority"),
+				"scheme://%61uthority/",
+			),
+		];
+
+		for (input_uri, input_authority, expected) in vectors {
+			let mut uri = UriBuf::new(input_uri.to_string()).unwrap();
+			let authority = input_authority.map(|a| Authority::new(a).unwrap());
+			uri.set_authority(authority);
+			assert_eq!(uri.as_str(), *expected, "input uri: {input_uri}, authority: {input_authority:?}");
+		}
+	}
+
+	#[test]
 	fn path() {
 		let vectors: &[(&str, &str)] = &[
 			("http://example.org", ""),
@@ -1086,6 +1131,64 @@ mod tests {
 	}
 
 	#[test]
+	fn set_query() {
+		let vectors: &[(&str, Option<&str>, &str)] = &[
+			(
+				"scheme://authority/path#frag",
+				Some("query"),
+				"scheme://authority/path?query#frag",
+			),
+			(
+				"scheme://authority/path?query#frag",
+				None,
+				"scheme://authority/path#frag",
+			),
+			(
+				"scheme://authority/path#frag",
+				Some("%71uery"),
+				"scheme://authority/path?%71uery#frag",
+			),
+			(
+				"scheme://authority/path?%71uery#frag",
+				Some("%71uery=%62ar"),
+				"scheme://authority/path?%71uery=%62ar#frag",
+			),
+			(
+				"scheme://authority/path?%71uery#frag",
+				Some("query"),
+				"scheme://authority/path?query#frag",
+			),
+			(
+				"scheme://authority/path?%71uery#frag",
+				Some("%71uery"),
+				"scheme://authority/path?%71uery#frag",
+			),
+			(
+				"scheme://authority/path?%71uery#frag",
+				None,
+				"scheme://authority/path#frag",
+			),
+			(
+				"scheme://authority/path?%71uery#frag",
+				Some("%71uery"),
+				"scheme://authority/path?%71uery#frag",
+			),
+			(
+				"scheme://authority/path?%71uery#frag",
+				None,
+				"scheme://authority/path#frag",
+			),
+		];
+
+		for (input_uri, input_query, expected) in vectors {
+			let mut uri = UriBuf::new(input_uri.to_string()).unwrap();
+			let query = input_query.map(|q| Query::new(q).unwrap());
+			uri.set_query(query);
+			assert_eq!(uri.as_str(), *expected, "input uri: {input_uri}, query: {input_query:?}");
+		}
+	}
+
+	#[test]
 	fn fragment() {
 		let vectors: &[(&str, Option<&str>)] = &[
 			("http://example.org", None),
@@ -1104,6 +1207,64 @@ mod tests {
 				*expected,
 				"input: {input}"
 			);
+		}
+	}
+
+	#[test]
+	fn set_fragment() {
+		let vectors: &[(&str, Option<&str>, &str)] = &[
+			(
+				"scheme://authority/path",
+				Some("frag"),
+				"scheme://authority/path#frag",
+			),
+			(
+				"scheme://authority/path#frag",
+				None,
+				"scheme://authority/path",
+			),
+			(
+				"scheme://authority/path",
+				Some("%66rag"),
+				"scheme://authority/path#%66rag",
+			),
+			(
+				"scheme://authority/path#%66rag",
+				Some("%66rag"),
+				"scheme://authority/path#%66rag",
+			),
+			(
+				"scheme://authority/path#%66rag",
+				Some("frag"),
+				"scheme://authority/path#frag",
+			),
+			(
+				"scheme://authority/path#%66rag",
+				Some("%66rag"),
+				"scheme://authority/path#%66rag",
+			),
+			(
+				"scheme://authority/path#%66rag",
+				None,
+				"scheme://authority/path",
+			),
+			(
+				"scheme://authority/path?q#%66rag",
+				Some("%66rag"),
+				"scheme://authority/path?q#%66rag",
+			),
+			(
+				"scheme://authority/path?q#%66rag",
+				None,
+				"scheme://authority/path?q",
+			),
+		];
+
+		for (input_uri, input_fragment, expected) in vectors {
+			let mut uri = UriBuf::new(input_uri.to_string()).unwrap();
+			let fragment = input_fragment.map(|f| Fragment::new(f).unwrap());
+			uri.set_fragment(fragment);
+			assert_eq!(uri.as_str(), *expected, "input uri: {input_uri}, fragment: {input_fragment:?}");
 		}
 	}
 

--- a/src/uri/reference.rs
+++ b/src/uri/reference.rs
@@ -920,8 +920,7 @@ impl UriRefBuf {
 					let bytes = self.as_mut_vec();
 					let delim_end = start + 1;
 					bytes[start] = b'?';
-					bytes[delim_end..(delim_end + new_query.len())]
-						.copy_from_slice(new_query)
+					bytes[delim_end..(delim_end + new_query.len())].copy_from_slice(new_query)
 				},
 			},
 			None => {
@@ -975,8 +974,7 @@ impl UriRefBuf {
 					let bytes = self.as_mut_vec();
 					let delim_end = start + 1;
 					bytes[start] = b'#';
-					bytes[delim_end..(delim_end + new_fragment.len())]
-						.copy_from_slice(new_fragment)
+					bytes[delim_end..(delim_end + new_fragment.len())].copy_from_slice(new_fragment)
 				},
 			},
 			None => {

--- a/src/uri/reference.rs
+++ b/src/uri/reference.rs
@@ -915,12 +915,13 @@ impl UriRefBuf {
 			Some(new_query) => match crate::common::parse::find_query(self.as_bytes(), 0) {
 				Ok(range) => unsafe { self.replace(range, new_query.as_bytes()) },
 				Err(start) => unsafe {
+					let new_query = new_query.as_bytes();
 					self.allocate(start..start, new_query.len() + 1);
 					let bytes = self.as_mut_vec();
 					let delim_end = start + 1;
 					bytes[start] = b'?';
 					bytes[delim_end..(delim_end + new_query.len())]
-						.copy_from_slice(new_query.as_bytes())
+						.copy_from_slice(new_query)
 				},
 			},
 			None => {
@@ -969,12 +970,13 @@ impl UriRefBuf {
 			Some(new_fragment) => match crate::common::parse::find_fragment(self.as_bytes(), 0) {
 				Ok(range) => unsafe { self.replace(range, new_fragment.as_bytes()) },
 				Err(start) => unsafe {
+					let new_fragment = new_fragment.as_bytes();
 					self.allocate(start..start, new_fragment.len() + 1);
 					let bytes = self.as_mut_vec();
 					let delim_end = start + 1;
 					bytes[start] = b'#';
 					bytes[delim_end..(delim_end + new_fragment.len())]
-						.copy_from_slice(new_fragment.as_bytes())
+						.copy_from_slice(new_fragment)
 				},
 			},
 			None => {
@@ -1562,11 +1564,127 @@ mod tests {
 	}
 
 	#[test]
+	fn set_query() {
+		let vectors: &[(&[u8], Option<&str>, &[u8])] = &[
+			(
+				b"scheme://authority/path#frag",
+				Some("query"),
+				b"scheme://authority/path?query#frag",
+			),
+			(
+				b"scheme://authority/path?query#frag",
+				None,
+				b"scheme://authority/path#frag",
+			),
+			(
+				b"scheme://authority/path#frag",
+				Some("%71uery"),
+				b"scheme://authority/path?%71uery#frag",
+			),
+			(
+				b"scheme://authority/path?%71uery#frag",
+				Some("%71uery=%62ar"),
+				b"scheme://authority/path?%71uery=%62ar#frag",
+			),
+			(
+				b"scheme://authority/path?%71uery#frag",
+				Some("query"),
+				b"scheme://authority/path?query#frag",
+			),
+			(
+				b"scheme://authority/path?%71uery#frag",
+				Some("%71uery"),
+				b"scheme://authority/path?%71uery#frag",
+			),
+			(
+				b"scheme://authority/path?%71uery#frag",
+				None,
+				b"scheme://authority/path#frag",
+			),
+			(
+				b"scheme://authority/path?%71uery#frag",
+				Some("%71uery"),
+				b"scheme://authority/path?%71uery#frag",
+			),
+			(
+				b"scheme://authority/path?%71uery#frag",
+				None,
+				b"scheme://authority/path#frag",
+			),
+		];
+
+		for (input_uri, input_query, expected) in vectors {
+			let mut buffer = UriRefBuf::new(input_uri.to_vec()).unwrap();
+			let query = input_query.map(|q| Query::new(q).unwrap());
+			buffer.set_query(query);
+			assert_eq!(buffer.as_bytes(), *expected);
+		}
+	}
+
+	#[test]
 	fn fragment() {
 		for (input, expected) in PARTS {
 			let input = UriRef::new(input).unwrap();
 			// eprintln!("{input}: {expected:?}");
 			assert_eq!(input.fragment().map(Fragment::as_bytes), expected.4)
+		}
+	}
+
+	#[test]
+	fn set_fragment() {
+		let vectors: &[(&[u8], Option<&str>, &[u8])] = &[
+			(
+				b"scheme://authority/path",
+				Some("frag"),
+				b"scheme://authority/path#frag",
+			),
+			(
+				b"scheme://authority/path#frag",
+				None,
+				b"scheme://authority/path",
+			),
+			(
+				b"scheme://authority/path",
+				Some("%66rag"),
+				b"scheme://authority/path#%66rag",
+			),
+			(
+				b"scheme://authority/path#%66rag",
+				Some("%66rag"),
+				b"scheme://authority/path#%66rag",
+			),
+			(
+				b"scheme://authority/path#%66rag",
+				Some("frag"),
+				b"scheme://authority/path#frag",
+			),
+			(
+				b"scheme://authority/path#%66rag",
+				Some("%66rag"),
+				b"scheme://authority/path#%66rag",
+			),
+			(
+				b"scheme://authority/path#%66rag",
+				None,
+				b"scheme://authority/path",
+			),
+			(
+				b"scheme://authority/path?q#%66rag",
+				Some("%66rag"),
+				b"scheme://authority/path?q#%66rag",
+			),
+			(
+				b"scheme://authority/path?q#%66rag",
+				None,
+				b"scheme://authority/path?q",
+			),
+		];
+
+		for (input_uri, input_fragment, expected) in vectors {
+			let mut buffer = UriRefBuf::new(input_uri.to_vec()).unwrap();
+			let fragment = input_fragment.map(|f| Fragment::new(f).unwrap());
+			buffer.set_fragment(fragment);
+			assert_eq!(buffer.as_bytes(), *expected);
 		}
 	}
 

--- a/src/uri/reference.rs
+++ b/src/uri/reference.rs
@@ -1599,16 +1599,6 @@ mod tests {
 				None,
 				b"scheme://authority/path#frag",
 			),
-			(
-				b"scheme://authority/path?%71uery#frag",
-				Some("%71uery"),
-				b"scheme://authority/path?%71uery#frag",
-			),
-			(
-				b"scheme://authority/path?%71uery#frag",
-				None,
-				b"scheme://authority/path#frag",
-			),
 		];
 
 		for (input_uri, input_query, expected) in vectors {
@@ -1655,11 +1645,6 @@ mod tests {
 				b"scheme://authority/path#%66rag",
 				Some("frag"),
 				b"scheme://authority/path#frag",
-			),
-			(
-				b"scheme://authority/path#%66rag",
-				Some("%66rag"),
-				b"scheme://authority/path#%66rag",
 			),
 			(
 				b"scheme://authority/path#%66rag",


### PR DESCRIPTION
Hi, thank you for your awesome work!

I've noticed while working with iref that certain set operations that use PctStr/PctString behind the scenes panic when encoding is used due to the duality of "length of decoded string" versus "byte length".

There's also another minor bug specific to set_host which doesn't allow the host to grow.

I also added some tests to set_authority even though I did not find any bugs related to that. Just did it for peace of mind/regression testing.

Thank you.